### PR TITLE
ci: allow to run renovate from github workflows

### DIFF
--- a/.github/workflows/renovate-ci.yml
+++ b/.github/workflows/renovate-ci.yml
@@ -3,6 +3,8 @@ name: Renovate
 on:
   schedule:
     - cron: "0 0 * * 0"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   renovate:


### PR DESCRIPTION
## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
<!--- Add here link to Jira, but let this not be the only content in this section -->
